### PR TITLE
2.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "restructuredpython"
-version = "2.5.1.post0"
+version = "2.6.0"
 requires-python = ">= 3.10"
 description = "A superset of Python with many new features, including full JS integration, multiline comments, header files, and optional curly brackets around control statements"
 authors = [{name = "Rihaan Meher", email = "meherrihaan@gmail.com"}]

--- a/restructuredpython/restructuredpython.py
+++ b/restructuredpython/restructuredpython.py
@@ -26,7 +26,7 @@ from .cload import *
 from .tempload import *
 from textformat import *
 
-__version__ = "2.5.1"
+__version__ = "2.6.0"
 
 
 def compile_header_file(header_filename, mode="classic"):


### PR DESCRIPTION
## Summary by Sourcery

Bump project version to 2.6.0 for the upcoming release

Chores:
- Update version in pyproject.toml to 2.6.0
- Update __version__ constant in source module to 2.6.0